### PR TITLE
add extra include file <typeinfo>, to avoid build error in VS2019

### DIFF
--- a/include/emock/ApiHookFunctor.h
+++ b/include/emock/ApiHookFunctor.h
@@ -93,7 +93,7 @@ void* ApiHookFunctor<R CallingConvention (DECL_ARGS(n) VariadicList), Seq>::apiA
 template <typename R DECL_TEMPLATE_ARGS(n), unsigned int Seq> \
 unsigned int ApiHookFunctor<R CallingConvention (DECL_ARGS(n) VariadicList), Seq>::refCount = 0 
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(_WIN64)
 #define EMOCK_API_HOOK_FUNCTOR_DEF(n) \
 __EMOCK_API_HOOK_FUNCTOR_DEF(n, , ); \
 __EMOCK_API_HOOK_FUNCTOR_DEF(n, __stdcall, ); \

--- a/include/emock/ProcStub.h
+++ b/include/emock/ProcStub.h
@@ -117,7 +117,7 @@ private: \
     Func func; \
 }
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(_WIN64)
 #define PROC_STUB_DEF(n) \
 __PROC_STUB_DEF(n, ); \
 __PROC_STUB_DEF(n, __stdcall)

--- a/include/emock/ResultHandlerFactory.h
+++ b/include/emock/ResultHandlerFactory.h
@@ -26,6 +26,8 @@
 
 #include <emock/emock.h>
 #include <string>
+#include <typeinfo>
+
 
 EMOCK_NS_START
 


### PR DESCRIPTION
In fact, there is no build issue in VS2017. 

But may be some header file change in VS2019, it fails.
